### PR TITLE
Make getSuff work with tibbles

### DIFF
--- a/R/getSuff.R
+++ b/R/getSuff.R
@@ -105,7 +105,7 @@ getSuff <- function(X, test = c("gaussCItest", "gaussMItest", "disCItest", "disM
     if (is.null(adaptDF)) { stop("'adaptDF' needs to be specified. See ?pcalg::disCItest") }
     if (!is.null(nlev)) { if (length(nlev) != ncol(X)) {stop("Something is wrong with nlev. Check ?pcalg::disCItest")} }
     for (i in 1:ncol(X)) {
-      X[ ,i] <- as.numeric(X[ ,i]) - 1
+      X[[i]] <- as.numeric(X[[i]]) - 1
     }
 
     if(is.null(adaptDF)) adaptDF = TRUE


### PR DESCRIPTION
Accessing using `[[i]]` is safer and works with tibbles too.

Issue before:

``` r
mwe <- tibble::tibble(
  x = factor(c(rep("a", 5), rep("b", 5))),
  y = factor(c(rep(c("a", "b"), 5)))
)

micd::mixCItest(1, 2, NULL, suffStat = as.data.frame(mwe))
#> [1] 0.5256929

micd::mixCItest(1, 2, NULL, suffStat = mwe)
#> Error in `getSuff()`:
#> ! 'list' object cannot be coerced to type 'double'
```

<sup>Created on 2026-06-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
